### PR TITLE
Use zero width space

### DIFF
--- a/modules/commands/index.js
+++ b/modules/commands/index.js
@@ -34,8 +34,8 @@ module.exports = function (client) {
       embed
           .setColor('#94df03')
           .setTitle('Available commands:')
-          .addField('-', leftList, true)
-          .addField('-', rightList, true);
+          .addField('\u200E', leftList, true)
+          .addField('\u200E', rightList, true);
 
       await message.channel.send({ embed });
       return;


### PR DESCRIPTION
Embed fields support the usage of zero width space (`\u200E`) inside them.
If JS for whatever reason doesn't support this... F*ck JS