### PR TITLE
Use Zero-width space for better look

### DIFF
--- a/modules/commands/list.json
+++ b/modules/commands/list.json
@@ -167,8 +167,8 @@
         "inline": true
       },
       {
-        "key": "-",
-        "value": "-",
+        "key": "\u200E",
+        "value": "\u200E",
         "inline": true
       }
     ],


### PR DESCRIPTION
For the record: Zero width spaces are confirmed to work (see https://github.com/LuckPerms/clippy/pull/17#issuecomment-622101459)
I would've been surprised if they didn't as they aren't really a language/platform dependant thing