### PR TITLE
change people to members

### DIFF
--- a/modules/no-ping.js
+++ b/modules/no-ping.js
@@ -18,7 +18,7 @@ module.exports = function (client) {
 
     if (mentionsStaff) {
       // Tell them off:
-      await msg.channel.send(`Hey ${msg.author.username}! Please don't tag helpful/staff people directly.`);
+      await msg.channel.send(`Hey ${msg.author.username}! Please don't tag helpful/staff members directly.`);
     }
   });
 };


### PR DESCRIPTION
Changes `people` to `members` which imo sounds nicer and makes more sense as those "people" are members of the Discord.