### PR TITLE
Commands stuff

### DIFF
--- a/modules/commands/list.json
+++ b/modules/commands/list.json
@@ -548,12 +548,12 @@
     ]
   },
   {
-    "name": "libraries",
+    "name": "libsdir",
     "aliases": [
       "libs", "dependencies"
     ],
     "title": "LuckPerms dependencies",
-    "description": "LuckPerms requires several libraries to work and make use of various functionalities. If you're getting a startup error such as `NoClassDefFoundError`, `ClassNotFoundException` or \"Unable to load dependency...\", stop your server, delete the `/plugins/LuckPerms/libs/` directory and start it up again."
+    "description": "LuckPerms requires several libraries in order to operate. If you're getting a startup error such as `NoClassDefFoundError`, `ClassNotFoundException` or \"Unable to load dependency...\", stop your server, delete the `/plugins/LuckPerms/libs/` directory and start it up again."
   },
   {
     "name": "cookbook",
@@ -562,6 +562,6 @@
     ],
     "title": "API Cookbook",
     "url": "https://github.com/LuckPerms/api-cookbook",
-    "description": "You can read some simple examples on how to do various queries or changes to users and groups, listen to LuckPerms events, and more."
+    "description": "The cookbook is a working example plugin which shows how to get/change data for users and groups, listen to LuckPerms events, and more."
   }
 ]

--- a/modules/commands/list.json
+++ b/modules/commands/list.json
@@ -554,5 +554,14 @@
     ],
     "title": "LuckPerms dependencies",
     "description": "LuckPerms requires several libraries to work and make use of various functionalities. If you're getting a startup error such as `NoClassDefFoundError`, `ClassNotFoundException` or \"Unable to load dependency...\", stop your server, delete the `/plugins/LuckPerms/libs/` directory and start it up again."
+  },
+  {
+    "name": "cookbook",
+    "aliasas": [
+      "apicookbook", "apiexamples"
+    ],
+    "title": "API Cookbook",
+    "url": "https://github.com/LuckPerms/api-cookbook",
+    "description": "You can read some simple examples on how to do various queries or changes to users and groups, listen to LuckPerms events, and more."
   }
 ]

--- a/modules/commands/list.json
+++ b/modules/commands/list.json
@@ -260,6 +260,9 @@
   },
   {
     "name": "argumentbased",
+    "aliases": [
+      "argbased"
+    ],
     "title": "Argument based command permissions",
     "url": "https://github.com/lucko/LuckPerms/wiki/Argument-based-command-permissions",
     "description": "Fine tune exactly what users with permission to use LuckPerms can do.",
@@ -267,6 +270,9 @@
   },
   {
     "name": "api",
+    "aliases": [
+      "javadoc", "javadocs"
+    ],
     "title": "Developer API",
     "url": "https://github.com/lucko/LuckPerms/wiki/Developer-API",
     "description": "Learn how to use the LuckPerms API in your project.",
@@ -274,6 +280,10 @@
       {
         "key": "Example usages",
         "value": "https://github.com/lucko/LuckPerms/wiki/Developer-API:-Usage"
+      },
+      {
+        "key": "Read the Javadoc",
+        "value": "https://javadoc.io/doc/net.luckperms/api/latest/index.html"
       }
     ],
     "wiki": true
@@ -349,6 +359,9 @@
   },
   {
     "name": "whyluckperms",
+    "aliases": [
+      "whylp"
+    ],
     "title": "Why LuckPerms",
     "url": "https://github.com/lucko/LuckPerms/wiki/Why-LuckPerms",
     "description": "Why should you choose LuckPerms? Read here to find out.",
@@ -437,7 +450,7 @@
   {
     "name": "suggestions",
     "aliases": [
-      "suggest", "bugreport"
+      "suggestion", "suggest", "bugreport", "issues", "issue"
     ],
     "title": "Suggestions and Bug Reports",
     "description": "If you would like to request a feature for LuckPerms, or report a bug, feel free to open an issue on GitHub!",
@@ -533,5 +546,13 @@
         "value": "https://nucleuspowered.org/docs/nowildcard.html"
       }
     ]
+  },
+  {
+    "name": "libraries",
+    "aliases": [
+      "libs", "dependencies"
+    ],
+    "title": "LuckPerms dependencies",
+    "description": "LuckPerms requires several libraries to work and make use of various functionalities. If you're getting a startup error such as `NoClassDefFoundError`, `ClassNotFoundException` or \"Unable to load dependency...\", stop your server, delete the `/plugins/LuckPerms/libs/` directory and start it up again."
   }
 ]


### PR DESCRIPTION
* Added `libraries` (and aliases) for when people need to delete the `/libs/` directory.
* Added a few aliases (`issues`, `whylp`, `javadoc` and `argbased`)
* Added a new field to the `api` command so it links to the API Javadoc.
* Added `cookbook` (and aliases) to summon the api-cookbook repo URL.