### PR TITLE
Use the guild member's nickname rather than their username

### DIFF
--- a/modules/no-ping.js
+++ b/modules/no-ping.js
@@ -19,7 +19,7 @@ module.exports = (client) => {
 
     if (mentionsStaff) {
       // Tell them off:
-      await msg.channel.send(`Hey ${msg.author.username}! Please don't tag helpful/staff members directly.`);
+      await msg.channel.send(`Hey ${msg.member.nickname ?? msg.author.username}! Please don't tag helpful/staff members directly.`);
     }
   });
 };


### PR DESCRIPTION
https://discord.js.org/#/docs/main/master/class/Message?scrollTo=member
https://discord.js.org/#/docs/main/master/class/GuildMember?scrollTo=nickname
Helpful for things like this
<img width="967" alt="Screen Shot 2021-02-03 at 5 49 55 PM" src="https://user-images.githubusercontent.com/26070412/106833569-96e1f000-6648-11eb-8b87-2eb745b19f17.png">
