### PR TITLE
Create logs folder if not present.

### DIFF
--- a/modules/log.js
+++ b/modules/log.js
@@ -1,6 +1,10 @@
 const dateFormat = require('dateformat');
 const fs = require('fs');
 
+fs.mkdir('./logs/', (err) => {
+  if (err) throw err;
+});
+
 const getLogFileName = (date) => 'logs/' + dateFormat(date, 'yyyy-mm-dd') + '.log';
 const getLogFileTime = (date) => dateFormat(date, 'hh-MM-ss TT');
 


### PR DESCRIPTION
Got this errors while testing the bot for the first time, realised its due to the `logs` folder not being created.
```
[Error: ENOENT: no such file or directory, open 'C:\Users\Ben10\Documents\GitHub\clippy\logs\2021-03-30.log'] {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'open',
  path: 'C:\\Users\\Ben10\\Documents\\GitHub\\clippy\\logs\\2021-03-30.log'
}
```
