### PR TITLE
New Alias For "Migration"

### DIFF
--- a/modules/commands/list.json
+++ b/modules/commands/list.json
@@ -193,6 +193,8 @@
   },
   {
     "name": "migration",
+    "aliases": [
+      "migrate"
     "title": "Migration",
     "url": "https://luckperms.net/wiki/Migration",
     "description": "Learn about the process of migrating from another permission plugin.",


### PR DESCRIPTION
This PR makes "migrate" an alias of "migration".
I think it would be useful to have !migrate as an alias to !migration.
