### PR TITLE
Update commandequivalents link

### DIFF
--- a/modules/triggers/triggers/embeds/list.json
+++ b/modules/triggers/triggers/embeds/list.json
@@ -339,7 +339,7 @@
       "equivalents"
     ],
     "title": "Command Equivalents",
-    "url": "https://luckperms.net/wiki/GM-&-PEX-Command-Equivalents",
+    "url": "https://luckperms.net/wiki/Migrating-from-GroupManager-or-PermissionsEx",
     "description": "Helpful page for people coming from other permission plugins.",
     "wiki": true
   },


### PR DESCRIPTION
Updated the command equivalents wiki link as it was moved to a different section of the wiki.