### PR TITLE
Add LPC embed

### DIFF
--- a/modules/triggers/triggers/embeds/list.json
+++ b/modules/triggers/triggers/embeds/list.json
@@ -712,5 +712,16 @@
         "value": "https://ore.spongepowered.org/Luck/LuckPerms/versions/5.3.98"
       }
     ]
+  },
+  {
+    "name": "lpc",
+    "title": "Using LuckPermsChat or LPC?",
+    "description": "LPC is not affiliated with Luckperms, and support for LPC is not provided here.",
+    "fields": [
+      {
+        "key": "LPC homepage",
+        "value": "https://www.spigotmc.org/resources/lpc-chat-formatter-1-7-10-1-20.68965/"
+      }
+    ]
   }
 ]

--- a/modules/triggers/triggers/embeds/list.json
+++ b/modules/triggers/triggers/embeds/list.json
@@ -720,7 +720,7 @@
     "fields": [
       {
         "key": "LPC homepage",
-        "value": "https://www.spigotmc.org/resources/lpc-chat-formatter-1-7-10-1-20.68965/"
+        "value": "https://www.spigotmc.org/resources/lpc.68965"
       }
     ]
   }


### PR DESCRIPTION
Embed lets users know that Luckperms does not provide support for LPC (LuckPermsChat).
A link is provided to the plugins homepage.
`lpc` to trigger. No aliases.