### PR TITLE
Add permplugin embed

### DIFF
--- a/modules/triggers/triggers/embeds/list.json
+++ b/modules/triggers/triggers/embeds/list.json
@@ -727,7 +727,7 @@
   {
     "name": "permplugin",
     "aliases": ["powerranks", "pex", "gm"],
-    "title": "Do you have more than one permissions plugin installed?",
+    "title": "More than one permissions plugin installed?",
     "description": "For LuckPerms to work properly & handle all permission checks, it must be the only permission plugin installed on your server (unless you are in the process of performing automatic migration).",
     "fields": [
       {

--- a/modules/triggers/triggers/embeds/list.json
+++ b/modules/triggers/triggers/embeds/list.json
@@ -723,5 +723,17 @@
         "value": "https://www.spigotmc.org/resources/lpc.68965"
       }
     ]
+  },
+  {
+    "name": "permplugin",
+    "aliases": ["powerranks", "pex", "gm"],
+    "title": "Using another permissions manager?",
+    "description": "For LuckPerms to fully work & handle all permission checks, it must be the only permission plugin installed on your server (unless you want to perform automatic migration)!",
+    "fields": [
+      {
+        "key": "Read more:",
+        "value": "https://luckperms.net/wiki/Installation#other-permission-plugins"
+      }
+    ]
   }
 ]

--- a/modules/triggers/triggers/embeds/list.json
+++ b/modules/triggers/triggers/embeds/list.json
@@ -727,11 +727,11 @@
   {
     "name": "permplugin",
     "aliases": ["powerranks", "pex", "gm"],
-    "title": "Using another permissions manager?",
-    "description": "For LuckPerms to fully work & handle all permission checks, it must be the only permission plugin installed on your server (unless you want to perform automatic migration)!",
+    "title": "Do you have more than one permissions plugin installed?",
+    "description": "For LuckPerms to work properly & handle all permission checks, it must be the only permission plugin installed on your server (unless you are in the process of performing automatic migration).",
     "fields": [
       {
-        "key": "Read more:",
+        "key": "More info",
         "value": "https://luckperms.net/wiki/Installation#other-permission-plugins"
       }
     ]


### PR DESCRIPTION
This PR introduces a new `permplugin` embed trigger to address compatibility issues that arise when other plugins are concurrently installed. Includes aliases associated with permission plugins used alongside LuckPerms: `powerranks`, `pex`, `gm`.

Open to feedback and suggestions regarding the content of the embed. 

![image](https://github.com/LuckPerms/clippy/assets/44745161/9e150db6-9abf-44ba-90d1-9f0106a45b20)
